### PR TITLE
Export sprockets by CommonJS style

### DIFF
--- a/src/sprockets.js
+++ b/src/sprockets.js
@@ -17,4 +17,4 @@ sprockets.declare = function(assetPaths, manifestPath) {
   manifest.init(manifestPath);
 };
 
-export default sprockets;
+module.exports = sprockets;


### PR DESCRIPTION
Babel 6 transforms code like `export default a;` to `exports.default = a;` ([doc](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/)). This is not a problem while we write code in ES2015, but confusing when we don't use Babel because the `require` function imports an object `{ default: sprockets }` instead of the sprockets module itself.

``` javascript
// So we have to write like this.
const sprockets = require('gulp-sprockets').default;
```

I think the public module should be exported by CommonJS style to avoid this.
(And this will fix the issue #3)
